### PR TITLE
feat: add `open_file`, `open_dir` and `save_file`

### DIFF
--- a/examples/minimal.v
+++ b/examples/minimal.v
@@ -11,7 +11,7 @@ if !dialog.message('Do you want to continue?', buttons: .yes_no) {
 input := dialog.prompt('What is your pets name?')
 dump(input)
 
-selected_file := dialog.file_dialog()
+selected_file := dialog.open_file()
 dump(selected_file)
 
 selected_color := dialog.color_picker()

--- a/src/_c.v
+++ b/src/_c.v
@@ -30,11 +30,11 @@ fn C.osdialog_prompt(level int, message &char, text &char) &char
 fn C.osdialog_file(action int, path &char, filename &char, filters C.osdialog_filters) &char
 fn C.osdialog_color_picker(color &C.osdialog_color, opacity int) int
 
-fn dialog_c__file_dialog() ?string {
-	path := C.osdialog_file(int(FileAction.open), unsafe { nil }, unsafe { nil }, unsafe { nil })
+fn dialog_c__file_dialog(action FileAction, path &char, filename &char) ?string {
+	selected := C.osdialog_file(int(action), path, filename, unsafe { nil })
 	unsafe {
-		if path != nil {
-			return path.vstring()
+		if selected != nil {
+			return selected.vstring()
 		}
 	}
 	return none

--- a/src/_default.c.v
+++ b/src/_default.c.v
@@ -8,8 +8,21 @@ fn dialog__prompt(message string, opts PromptOptions) ?string {
 	return dialog_c__prompt(message, opts)
 }
 
+[deprecated]
 fn dialog__file_dialog() ?string {
-	return dialog_c__file_dialog()
+	return unsafe { dialog_c__file_dialog(.open, nil, nil) }
+}
+
+fn dialog__open_file(opts FileOpenOptions) ?string {
+	return dialog_c__file_dialog(.open, &char(opts.path.str), unsafe { nil })
+}
+
+fn dialog__open_dir(opts FileOpenOptions) ?string {
+	return dialog_c__file_dialog(.open_dir, &char(opts.path.str), unsafe { nil })
+}
+
+fn dialog__save_file(opts FileSaveOptions) ?string {
+	return dialog_c__file_dialog(.save, &char(opts.path.str), &char(opts.filename.str))
 }
 
 fn dialog__color_picker(opts ColorPickerOptions) ?Color {

--- a/src/_macos.c.v
+++ b/src/_macos.c.v
@@ -18,12 +18,37 @@ fn dialog__prompt(message string, opts PromptOptions) ?string {
 	return dialog_c__prompt(message, opts)
 }
 
+[deprecated]
 fn dialog__file_dialog() ?string {
 	w := webview.create()
 	defer {
 		w.destroy()
 	}
-	return dialog_c__file_dialog()
+	return unsafe { dialog_c__file_dialog(.open, nil, nil) }
+}
+
+fn dialog__open_file(opts FileOpenOptions) ?string {
+	w := webview.create()
+	defer {
+		w.destroy()
+	}
+	return dialog_c__file_dialog(.open, &char(opts.path.str), unsafe { nil })
+}
+
+fn dialog__open_dir(opts FileOpenOptions) ?string {
+	w := webview.create()
+	defer {
+		w.destroy()
+	}
+	return dialog_c__file_dialog(.open_dir, &char(opts.path.str), unsafe { nil })
+}
+
+fn dialog__save_file(opts FileSaveOptions) ?string {
+	w := webview.create()
+	defer {
+		w.destroy()
+	}
+	return dialog_c__file_dialog(.save, &char(opts.path.str), &char(opts.filename.str))
 }
 
 fn dialog__color_picker(opts ColorPickerOptions) ?Color {

--- a/src/lib.v
+++ b/src/lib.v
@@ -18,6 +18,17 @@ pub struct PromptOptions {
 }
 
 [params]
+pub struct FileOpenOptions {
+	path string // is the default folder the dialog will attempt to open in.
+}
+
+[params]
+pub struct FileSaveOptions {
+	path     string // is the default folder the dialog will attempt to open in.
+	filename string // is the default text that will appear in the filename input.
+}
+
+[params]
 pub struct ColorPickerOptions {
 	color   Color // is the initial color.
 	opacity bool = true // can be set to `false` to disable the opacity slider on Linux.
@@ -55,9 +66,24 @@ pub enum MessageLevel {
 pub type Color = C.osdialog_color
 
 // file_dialog opens a file dialog and returns the selected path or `none` if the selection was canceled.
-// TODO: file_dialog params struct
+[deprecated: 'will be removed with v0.3; use `open_file()` instead.']
 pub fn file_dialog() ?string {
 	return dialog__file_dialog()
+}
+
+// open_file opens a file dialog and returns the selected path or `none` if the selection was canceled.
+pub fn open_file(opts FileOpenOptions) ?string {
+	return dialog__open_file(opts)
+}
+
+// open_dir opens a file dialog and returns the selected directory path or `none` if the selection was canceled.
+pub fn open_dir(opts FileOpenOptions) ?string {
+	return dialog__open_dir(opts)
+}
+
+// save_file opens a file dialog for saving and returns the selected path or `none` if the selection was canceled.
+pub fn save_file(opts FileSaveOptions) ?string {
+	return dialog__save_file(opts)
 }
 
 // message launches a message box and returns `true` if `OK` or `Yes` was pressed.


### PR DESCRIPTION
Adds:
- `open_file` - resembles current `file_dialog`
- `open_dir`
- `save_file`

Marks `file_dialog` as deprecated.

