### PR TITLE
feat!: use file_dialog to get paths and new fns to perform their semantic actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ if !dialog.message('Do you want to continue?', buttons: .yes_no) {
 input := dialog.prompt('What is your pets name?')
 dump(input)
 
-selected_file := dialog.open_file()
+selected_file := dialog.file_dialog()
 dump(selected_file)
 
 selected_color := dialog.color_picker()

--- a/README.md
+++ b/README.md
@@ -80,18 +80,24 @@ pub fn message(message string, opts MessageOptions) bool
 // prompt launches an input prompt with an "OK" and "Cancel" button.
 pub fn prompt(message string, opts PromptOptions) ?string
 
-// open_file opens a file dialog and returns the selected path or `none` if the selection was canceled.
-// Optionally, `path` can be specified as the default folder the dialog will attempt to open in.
-pub fn open_file(opts FileOpenOptions) ?string
+// file_dialog opens a file dialog and returns the selected path or `none` if the selection was canceled.
+pub fn file_dialog(opts FileDialogOptions) ?string
 
-// open_dir opens a file dialog and returns the selected directory path or `none` if the selection was canceled.
+// open_file opens a file dialog reads the selected path.
 // Optionally, `path` can be specified as the default folder the dialog will attempt to open in.
-pub fn open_dir(opts FileOpenOptions) ?string
+// It returns an error if the selection is cancelled or the reading the file fails.
+pub fn open_file(opts FileOpenOptions) !string
 
-// save_file opens a file dialog for saving and returns the selected path or `none` if the selection was canceled.
-// Optionally, `path` can be specified as the default folder the dialog will attempt to open in, and `filename`
-// to set the default text that will appear in the filename input.
-pub fn save_file(opts FileSaveOptions) ?string
+// open_dir opens a file dialog and returns a list with the paths of the selected directory contents.
+// Optionally, `path` can be specified as the default folder the dialog will attempt to open in.
+// It returns an error if the selection is cancelled or the reading the directory contents fails.
+pub fn open_dir(opts FileOpenOptions) ![]string
+
+// save_file opens a file dialog and saves the given content to the selected path.
+// Optionally, `path` can be specified as the default folder the dialog will attempt to open in.
+// `filename` can be provided to set the default text that will appear in the filename input.
+// It returns an error if the selection is cancelled or the writing the file fails.
+pub fn save_file(opts FileSaveOptions) !
 
 // color_picker opens an RGBA color picker dialog and returns the selected color or `none` if the
 // selection was canceled. Optionally, it takes a `color` and `opacity` argument. `color` sets the

--- a/examples/minimal.v
+++ b/examples/minimal.v
@@ -11,7 +11,7 @@ if !dialog.message('Do you want to continue?', buttons: .yes_no) {
 input := dialog.prompt('What is your pets name?')
 dump(input)
 
-selected_file := dialog.open_file()
+selected_file := dialog.file_dialog()
 dump(selected_file)
 
 selected_color := dialog.color_picker()

--- a/src/_default.c.v
+++ b/src/_default.c.v
@@ -8,9 +8,8 @@ fn dialog__prompt(message string, opts PromptOptions) ?string {
 	return dialog_c__prompt(message, opts)
 }
 
-[deprecated]
-fn dialog__file_dialog() ?string {
-	return unsafe { dialog_c__file_dialog(.open, nil, nil) }
+fn dialog__file_dialog(opts FileDialogOptions) ?string {
+	return dialog_c__file_dialog(opts.action, &char(opts.path.str), &char(opts.filename.str))
 }
 
 fn dialog__open_file(opts FileOpenOptions) ?string {

--- a/src/_macos.c.v
+++ b/src/_macos.c.v
@@ -18,13 +18,12 @@ fn dialog__prompt(message string, opts PromptOptions) ?string {
 	return dialog_c__prompt(message, opts)
 }
 
-[deprecated]
-fn dialog__file_dialog() ?string {
+fn dialog__file_dialog(opts FileDialogOptions) ?string {
 	w := webview.create()
 	defer {
 		w.destroy()
 	}
-	return unsafe { dialog_c__file_dialog(.open, nil, nil) }
+	return dialog_c__file_dialog(opts.action, &char(opts.path.str), &char(opts.filename.str))
 }
 
 fn dialog__open_file(opts FileOpenOptions) ?string {

--- a/src/lib.v
+++ b/src/lib.v
@@ -5,6 +5,8 @@
 // Source: https://github.com/ttytm/dialog
 module dialog
 
+import os
+
 [params]
 pub struct MessageOptions {
 	level   MessageLevel
@@ -15,6 +17,13 @@ pub struct MessageOptions {
 pub struct PromptOptions {
 	level MessageLevel
 	text  string // is the initial input text.
+}
+
+[params]
+pub struct FileDialogOptions {
+	action   FileAction
+	path     string // is the default folder the dialog will attempt to open in.
+	filename string // is the default text that will appear in the filename input. Only when the action is `.save`.
 }
 
 [params]
@@ -76,28 +85,44 @@ pub fn prompt(message string, opts PromptOptions) ?string {
 }
 
 // file_dialog opens a file dialog and returns the selected path or `none` if the selection was canceled.
-[deprecated: 'will be removed with v0.3; use `open_file()` instead.']
-pub fn file_dialog() ?string {
-	return dialog__file_dialog()
+pub fn file_dialog(opts FileDialogOptions) ?string {
+	return dialog__file_dialog(opts)
 }
 
-// open_file opens a file dialog and returns the selected path or `none` if the selection was canceled.
+// open_file opens a file dialog reads the selected path.
 // Optionally, `path` can be specified as the default folder the dialog will attempt to open in.
-pub fn open_file(opts FileOpenOptions) ?string {
-	return dialog__open_file(opts)
+// It returns an error if the selection is cancelled or the reading // the file fails.
+pub fn open_file(opts FileOpenOptions) !string {
+	if path := dialog__open_file(opts) {
+		return os.read_file(path) or { error('error: failed to read file from "${path}". ${err}') }
+	}
+	return error('error: no path selected.')
 }
 
-// open_dir opens a file dialog and returns the selected directory path or `none` if the selection was canceled.
+// open_dir opens a file dialog and returns a list with the paths of the selected directory contents.
 // Optionally, `path` can be specified as the default folder the dialog will attempt to open in.
-pub fn open_dir(opts FileOpenOptions) ?string {
-	return dialog__open_dir(opts)
+// It returns an error if the selection is cancelled or the reading the directory contents fails.
+pub fn open_dir(opts FileOpenOptions) ![]string {
+	if path := dialog__open_dir(opts) {
+		dir_contents := os.ls(path) or {
+			return error('error: failed to read directory contents from "${path}". ${err}')
+		}
+		return dir_contents.map(os.join_path(path, it))
+	}
+	return error('error: no path selected.')
 }
 
-// save_file opens a file dialog for saving and returns the selected path or `none` if the selection was canceled.
-// Optionally, `path` can be specified as the default folder the dialog will attempt to open in, and `filename`
-// to set the default text that will appear in the filename input.
-pub fn save_file(opts FileSaveOptions) ?string {
-	return dialog__save_file(opts)
+// save_file opens a file dialog and saves the given content to the selected path.
+// Optionally, `path` can be specified as the default folder the dialog will attempt to open in.
+// `filename` can be provided to set the default text that will appear in the filename input.
+// It returns an error if the selection is cancelled or the writing the file fails.
+pub fn save_file(content string, opts FileSaveOptions) ! {
+	if path := dialog__save_file(opts) {
+		os.write_file(path, content) or {
+			return error('error: failed to save file to "${path}". ${err}')
+		}
+	}
+	return error('error: no path selected.')
 }
 
 // color_picker opens an RGBA color picker dialog and returns the selected color or `none` if the


### PR DESCRIPTION
Removes deprecated attribute from `file_dialog` to use it for selected path returns and makes new function execute their related actions. E.g. `open_file` returns the contents of a selected file `save_file` saves the given contents to file_path selected in the file dialog.